### PR TITLE
Fix/java 1.5 support

### DIFF
--- a/src/main/java/com/intercognition/mailcheck/EmailAddress.java
+++ b/src/main/java/com/intercognition/mailcheck/EmailAddress.java
@@ -1,7 +1,5 @@
 package com.intercognition.mailcheck;
 
-import java.util.Arrays;
-
 public class EmailAddress {
 
     private String address;
@@ -17,8 +15,11 @@ public class EmailAddress {
 
         domain = parts[parts.length-1];
 
-        parts = Arrays.copyOfRange(parts,0,parts.length-1);
-        address = join(parts,"@");
+		final String[] tmp = new String[parts.length-1];
+		System.arraycopy(parts, 0, tmp, 0, parts.length-1);
+		parts = tmp;
+
+		address = join(parts,"@");
 
         tld = extractTld(domain);
         if(tld == null) valid = false;
@@ -69,7 +70,7 @@ public class EmailAddress {
             return false;
         }
         for(String part : parts) {
-            if(part.isEmpty()) {
+            if(part.length() == 0) {
                 return false;
             }
         }

--- a/src/main/java/com/intercognition/mailcheck/MailCheck.java
+++ b/src/main/java/com/intercognition/mailcheck/MailCheck.java
@@ -1,10 +1,9 @@
 package com.intercognition.mailcheck;
 
-import com.intercognition.mailcheck.config.Configuration;
-import com.intercognition.mailcheck.config.SimpleConfiguration;
-import com.intercognition.mailcheck.stringdistance.DistanceAlgorithm;
-
 import java.util.Collection;
+
+import com.intercognition.mailcheck.config.Configuration;
+import com.intercognition.mailcheck.stringdistance.DistanceAlgorithm;
 
 /**
  * Usage:
@@ -68,7 +67,7 @@ public class MailCheck {
         float smallestMatchDistance = 99;
         String closestMatch = null;
 
-        if (candidate == null || candidate.isEmpty() || possibleMatches == null || possibleMatches.isEmpty()) {
+        if (candidate == null || candidate.length() == 0 || possibleMatches == null || possibleMatches.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/com/intercognition/mailcheck/stringdistance/Sift3.java
+++ b/src/main/java/com/intercognition/mailcheck/stringdistance/Sift3.java
@@ -60,6 +60,6 @@ public class Sift3 implements DistanceAlgorithm {
     }
 
     private boolean isNullOrEmpty(String candidate) {
-        return candidate == null || candidate.isEmpty();
+        return candidate == null || candidate.length() == 0;
     }
 }

--- a/src/main/java/com/intercognition/mailcheck/stringdistance/Sift3.java
+++ b/src/main/java/com/intercognition/mailcheck/stringdistance/Sift3.java
@@ -26,7 +26,7 @@ public class Sift3 implements DistanceAlgorithm {
             return isNullOrEmpty(secondString) ? 0 : secondString.length();
         if (isNullOrEmpty(secondString))
             return firstString.length();
-        
+
         int c = 0;
         int offset1 = 0;
         int offset2 = 0;
@@ -56,7 +56,7 @@ public class Sift3 implements DistanceAlgorithm {
             }
             c++;
         }
-        return (firstString.length() + secondString.length())/2 - lcs;
+        return (firstString.length() + secondString.length())/2.0f - lcs;
     }
 
     private boolean isNullOrEmpty(String candidate) {

--- a/src/test/java/com/intercognition/mailcheck/stringdistance/Sift3Test.java
+++ b/src/test/java/com/intercognition/mailcheck/stringdistance/Sift3Test.java
@@ -1,9 +1,8 @@
 package com.intercognition.mailcheck.stringdistance;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class Sift3Test {
 
@@ -45,8 +44,8 @@ public class Sift3Test {
     }
 
     @Test
-    public void differenceFurtherThanMaximumOffsetBetweenStringsIsZero() {
-        assertEquals(0D, sift3.getDistance("abcdef", "abcdefg"), 0D);
+    public void differenceFurtherThanMaximumOffsetBetweenStringsIsCountedAsDistance() {
+        assertEquals(0D, sift3.getDistance("abcdef", "abcdefg"), 0.5f);
     }
 
     @Test
@@ -55,8 +54,8 @@ public class Sift3Test {
     }
 
     @Test
-    public void additionalCharacterWithinOffsetRangeIsNotCountedAsDistance() {
-        assertEquals(0D, sift3.getDistance("abc", "abcd"), 0D);
+    public void additionalCharacterWithinOffsetRangeIsCountedAsDistance() {
+        assertEquals(0D, sift3.getDistance("abc", "abcd"), 0.5f);
     }
 
 }


### PR DESCRIPTION
Android 2.2 devices are based on Java 1.5.

Two following APIs not available on Android 2.2:
- The String.isEmpty() method was introduced on Java 1.6. The 2.2 version of Android is based on Java 5. It was added only with API level 9 (Gingerbread). Replaced the isEmpty() call with “length() == 0”.
- The copyOfRange() method is another java 1.6 API that is being used by MailCheck. Replaced it with System.arraycopy()
